### PR TITLE
Fixes "clojure.lang.Symbol cannot be cast to clojure.lang.Associative"

### DIFF
--- a/src/leiningen/new/hoplon_castra.clj
+++ b/src/leiningen/new/hoplon_castra.clj
@@ -8,7 +8,7 @@
     tailrecursion/hoplon])
 
 (defn latest-deps-strs [deps]
-  (mapv (partial latest-version-string! {:snapshots? false}) deps))
+  (mapv #(latest-version-string! % {:snapshots? false}) deps))
 
 (defn hoplon-castra
   "Create new Hoplon project."


### PR DESCRIPTION
Running this template fails with:

``` bash
$ lein new hoplon-castra myproject
java.lang.ClassCastException: clojure.lang.Symbol cannot be cast to clojure.lang.Associative
...
    ancient_clj.core$latest_version_BANG_.doInvoke (core.clj:139)
```

Not sure how this could have ever worked, since `latest-version-string!` takes the option map _after_ the symbol. Even older version of `ancient-clj`, like 0.1.9 and 0.1.10, did that. But I have used this template myself, so I know it has worked at some point. Confusing.

Anyway, by changing from a partial to a fn that swaps the args, I got it to work. Hope it helps.
