### PR TITLE
Update to Clojure 1.8.0

### DIFF
--- a/src/leiningen/new/hoplon_castra.clj
+++ b/src/leiningen/new/hoplon_castra.clj
@@ -33,7 +33,7 @@
          ring-v
          ring-defaults-v] (latest-deps-strs deps)
         castra-v "3.0.0-SNAPSHOT"
-        clojure-v "1.7.0"
+        clojure-v "1.8.0"
         render  (t/renderer "hoplon-castra")
         main-ns (t/sanitize-ns name)
         data    {:raw-name        name


### PR DESCRIPTION
Updated to Clojure 1.8.0 as string/index-of is not available in Clojure 1.7.0
Projects created with the current template throw the following error when booted: 
`No such var: string/index-of`
