### PR TITLE
project's namespace replaced instead of hardcoded

### DIFF
--- a/src/leiningen/new/hoplon_castra/build.boot
+++ b/src/leiningen/new/hoplon_castra/build.boot
@@ -50,6 +50,6 @@
   (comp (hoplon)
         (cljs :optimizations :advanced)
         (uber :as-jars true)
-        (web :serve 'my-app.handler/app)
+        (web :serve '{{namespace}}.handler/app)
         (war)
         (target :dir #{"target"})))


### PR DESCRIPTION
When I followed directions [here](https://github.com/zlrth/hoplon-castra-template) I got a `java.io.FileNotFoundException: Could not locate my_app/handler__init.class or my_app/handler.clj on classpath`.

(I followed "war" directions, not "jar" directions.)

When I changed my project's `build.boot`, I was able to deploy my hoplon-castra app to heroku. Hope this helps!